### PR TITLE
Add a Vagrantfile for reproducible localdev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /magento
 /docker/.env
+.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /magento
 /docker/.env
 .vagrant
+/vagrant/.composer

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ composer require --ignore-platform-reqs --dev phpunit/phpunit ^6
             return $this;
         }
     }
+    ```
 1. Create new observer file in `Observer` folder and extend it from `SolveData\Events\Observer\ObserverAbstract` class. Specify your class as handler.
     ```
     class RegisterObserver extends ObserverAbstract

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,8 +1,26 @@
 ### NGINX #################################################
 
-NGINX_HOST_HTTP_PORT=80
-NGINX_HOST_HTTPS_PORT=443
+NGINX_HOST_HTTP_PORT=8081
+NGINX_HOST_HTTPS_PORT=4433
 NGINX_HOST_SITE_PATH=../../../../
+
+### PHP ###################################################
+
+# Web configuration
+MAGENTO_WEB_ADDRESS=127.0.0.1
+MAGENTO_WEB_PORT=8081 # Same as the NGINX HTTP port
+
+# Admin user configuration
+MAGENTO_ADMIN_FIRSTNAME=admin
+MAGENTO_ADMIN_LASTNAME=admin
+MAGENTO_ADMIN_EMAIL=admin@example.com
+MAGENTO_ADMIN_USER=admin
+MAGENTO_ADMIN_PASSWORD=123123Qa
+
+# Store configuration
+MAGENTO_LANGUAGE=en_US
+MAGENTO_CURRENCY=USD
+MAGENTO_TIMEZONE=UTC
 
 ### MYSQL #################################################
 
@@ -14,29 +32,6 @@ MYSQL_USER=solvedata
 MYSQL_PASSWORD=123123Qa
 MYSQL_HOST_CONF_FILE=./configs/mysql/mysql.cnf
 
-### REDIS #################################################
-
-REDIS_HOST_LOGS_PATH=./logs/redis
-
 ### PHPMYADMIN ############################################
 
 PHPMYADMIN_HOST_PORT=8080
-
-### PHPREDISADMIN #########################################
-
-PHPREDISADMIN_HOST_PORT=8282
-PHPREDISADMIN_ADMIN_USER=solvedata
-PHPREDISADMIN_ADMIN_PASS=123123Qa
-
-### ELASTICSEARCH #########################################
-
-ELASTICSEARCH_CLUSTER_NAME=magento
-ELASTICSEARCH_PASSWORD=123123Qa
-
-### KIBANA ################################################
-
-KIBANA_HOST_PORT=5601
-KIBANA_SERVER_NAME=localhost:5601
-KIBANA_ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-KIBANA_ELASTICSEARCH_USERNAME=elastic
-KIBANA_ELASTICSEARCH_PASSWORD=123123Qa

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,6 +1,6 @@
 ### NGINX #################################################
 
-NGINX_HOST_HTTP_PORT=8081
+NGINX_HOST_HTTP_PORT=8091
 NGINX_HOST_HTTPS_PORT=4433
 NGINX_HOST_SITE_PATH=../../../../
 
@@ -8,7 +8,7 @@ NGINX_HOST_SITE_PATH=../../../../
 
 # Web configuration
 MAGENTO_WEB_ADDRESS=127.0.0.1
-MAGENTO_WEB_PORT=8081 # Same as the NGINX HTTP port
+MAGENTO_WEB_PORT=8091 # Same as the NGINX HTTP port
 
 # Admin user configuration
 MAGENTO_ADMIN_FIRSTNAME=admin

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   nginx:
     image: nginx:latest
     ports:
-      - "${NGINX_HOST_HTTP_PORT}:80"
-      - "${NGINX_HOST_HTTPS_PORT}:443"
+      - ${NGINX_HOST_HTTP_PORT}:80
+      - ${NGINX_HOST_HTTPS_PORT}:443
     volumes:
       - ${NGINX_HOST_SITE_PATH}:/var/www:ro
       - ./configs/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
@@ -17,19 +17,48 @@ services:
     build: ./configs/php
     volumes:
       - ${NGINX_HOST_SITE_PATH}:/var/www
+    environment:
+      # Web configuration
+      - MAGENTO_WEB_ADDRESS
+      - MAGENTO_WEB_PORT
+
+      # Admin user configuration
+      - MAGENTO_ADMIN_FIRSTNAME
+      - MAGENTO_ADMIN_LASTNAME
+      - MAGENTO_ADMIN_EMAIL
+      - MAGENTO_ADMIN_USER
+      - MAGENTO_ADMIN_PASSWORD
+
+      # Store configuration
+      - MAGENTO_LANGUAGE
+      - MAGENTO_CURRENCY
+      - MAGENTO_TIMEZONE
+
+      # Database configuration
+      - MYSQL_HOST=mysql
+      - MYSQL_PORT
+      - MYSQL_DATABASE
+      - MYSQL_USER
+      - MYSQL_PASSWORD
     links:
       - mysql
 
   mysql:
     image: mysql:5.7
+    entrypoint:
+      - bash
+      - -c
+      - |
+        echo -e "[client]\ndatabase=${MYSQL_DATABASE}\nuser=${MYSQL_USER}\npassword=${MYSQL_PASSWORD}" > ~/.my.cnf
+        exec docker-entrypoint.sh mysqld
     ports:
-      - "${MYSQL_HOST_PORT}:${MYSQL_PORT}"
+      - ${MYSQL_HOST_PORT}:${MYSQL_PORT}
     environment:
-      - MYSQL_PORT=${MYSQL_PORT}
-      - MYSQL_DATABASE=${MYSQL_DATABASE}
-      - MYSQL_USER=${MYSQL_USER}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_PORT
+      - MYSQL_DATABASE
+      - MYSQL_USER
+      - MYSQL_PASSWORD
+      - MYSQL_ROOT_PASSWORD
     volumes:
       - ${MYSQL_HOST_CONF_FILE}:/etc/mysql/conf.d/mysql.cnf:ro
       - mysql:/var/lib/mysql

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,18 +7,25 @@ services:
       - ${NGINX_HOST_HTTP_PORT}:80
       - ${NGINX_HOST_HTTPS_PORT}:443
     volumes:
-      - "${NGINX_HOST_SITE_PATH}:/var/www:ro"
-      - /src:/var/www/vendor/solvedata/plugins-magento2:ro
       - ./configs/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./configs/nginx/ssl:/etc/nginx/ssl:ro
+      - type: bind
+        source: ${NGINX_HOST_SITE_PATH}
+        target: /var/www
+        read_only: true
+        bind:
+          propagation: shared
     links:
       - php-fpm
 
   php-fpm:
     build: ./configs/php
     volumes:
-      - "${NGINX_HOST_SITE_PATH}:/var/www"
-      - /src:/var/www/vendor/solvedata/plugins-magento2
+      - type: bind
+        source: ${NGINX_HOST_SITE_PATH}
+        target: /var/www
+        bind:
+          propagation: shared
     environment:
       # Web configuration
       - MAGENTO_WEB_ADDRESS

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       - ${NGINX_HOST_HTTP_PORT}:80
       - ${NGINX_HOST_HTTPS_PORT}:443
     volumes:
-      - ${NGINX_HOST_SITE_PATH}:/var/www:ro
+      - "${NGINX_HOST_SITE_PATH}:/var/www:ro"
+      - /src:/var/www/vendor/solvedata/plugins-magento2:ro
       - ./configs/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./configs/nginx/ssl:/etc/nginx/ssl:ro
     links:
@@ -16,7 +17,8 @@ services:
   php-fpm:
     build: ./configs/php
     volumes:
-      - ${NGINX_HOST_SITE_PATH}:/var/www
+      - "${NGINX_HOST_SITE_PATH}:/var/www"
+      - /src:/var/www/vendor/solvedata/plugins-magento2
     environment:
       # Web configuration
       - MAGENTO_WEB_ADDRESS

--- a/docker/tools.sh
+++ b/docker/tools.sh
@@ -117,8 +117,10 @@ case "${command}" in
                 | awk -F': ' '{print $2}'
         )"
 
-        echo "Magento store is running at ${url}"
-        echo "Magento Admin's UI is at ${url%?}${admin_path}"
+        echo "URLs:"
+        echo "  Store  : ${url}"
+        echo "  Admin  : ${url%?}${admin_path}"
+        echo "  Swagger: ${url%?}/swagger"
     ;;
 
     *)

--- a/docker/tools.sh
+++ b/docker/tools.sh
@@ -50,9 +50,9 @@ case "${command}" in
 
     recompile)
         echo "Regenerating Magento's generated code & content..."
-        bash "${DIR}/tools.sh" php_exec "sudo -u www-data php bin/magento setup:upgrade"
-        bash "${DIR}/tools.sh" php_exec "sudo -u www-data php bin/magento setup:di:compile"
-        bash "${DIR}/tools.sh" php_exec "sudo -u www-data php bin/magento setup:static-content:deploy --force"
+        bash "${DIR}/tools.sh" php_exec sudo -u www-data php bin/magento setup:upgrade
+        bash "${DIR}/tools.sh" php_exec sudo -u www-data php bin/magento setup:di:compile
+        bash "${DIR}/tools.sh" php_exec sudo -u www-data php bin/magento setup:static-content:deploy --force
     ;;
 
     setup_magento)
@@ -79,15 +79,15 @@ case "${command}" in
 
     setup_cron)
         echo "Starting magento cron jobs..."
-        "${DIR}/tools.sh" php_exec "sudo -u www-data php bin/magento cache:flush"
-        "${DIR}/tools.sh" php_exec "sudo -u www-data php bin/magento cron:install"
-        "${DIR}/tools.sh" php_exec "sudo -u www-data php bin/magento cron:run"
-        "${DIR}/tools.sh" php_exec "service rsyslog start"
-        "${DIR}/tools.sh" php_exec "service cron restart"
+        "${DIR}/tools.sh" php_exec sudo -u www-data php bin/magento cache:flush
+        "${DIR}/tools.sh" php_exec sudo -u www-data php bin/magento cron:install
+        "${DIR}/tools.sh" php_exec sudo -u www-data php bin/magento cron:run
+        "${DIR}/tools.sh" php_exec service rsyslog start
+        "${DIR}/tools.sh" php_exec service cron restart
     ;;
 
     admin_url)
-        bash "${DIR}/tools.sh" php_exec "sudo -u www-data php bin/magento info:adminuri"
+        bash "${DIR}/tools.sh" php_exec sudo -u www-data php bin/magento info:adminuri
     ;;
 
     *)
@@ -109,10 +109,10 @@ case "${command}" in
             ${DIR@Q}/tools.sh mysql_exec ...
 
         magento:
-            ${DIR@Q}/tools.sh  setup_mageneto
-            ${DIR@Q}/tools.sh  setup_cron
-            ${DIR@Q}/tools.sh  recompile
-            ${DIR@Q}/tools.sh  admin_url
+            ${DIR@Q}/tools.sh setup_mageneto
+            ${DIR@Q}/tools.sh setup_cron
+            ${DIR@Q}/tools.sh recompile
+            ${DIR@Q}/tools.sh admin_url
         "
         exit 1
     ;;

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ run_composer() {
     --volume "${COMPOSER_HOME:-$HOME/.composer}:/tmp" \
     --volume "${PWD}:/app" \
     --user "$(id -u):$(id -g)" \
-    composer:1.8.0 --profile -vvv "$@" || (
+    composer:2.0.13 --profile -vvv "$@" || (
       exit_code=$?
       echo "Exited with code: ${exit_code}"
       echo "If composer exited part way through without reason, it may have run out of memory"
@@ -18,7 +18,6 @@ run_composer() {
       echo "Composer needs about 1.7GB of memory to install Magento and 0.7GB to install other packages"
       exit 1
     )
-
 }
 
 MAGENTO_PATH="${MAGENTO_PATH:-magento}"

--- a/install.sh
+++ b/install.sh
@@ -3,20 +3,16 @@
 set -euxo pipefail
 TMP_DIR=$(mktemp -d)
 
-
-plugin_vcs_name='magento2-plugin'
-plugin_composer_name='plugins-magento2'
-
 run_composer() {
   # See https://hub.docker.com/_/composer for details around
   #   using a non-root user and mounting the SSH agent socket.
-  docker run --rm --interactive --tty \
+  docker run --rm \
     --volume "${COMPOSER_HOME:-$HOME/.composer}:/tmp" \
     --volume "${PWD}:/app" \
     --user "$(id -u):$(id -g)" \
     composer:1.8.0 --profile -vvv "$@" || (
       exit_code=$?
-      echo "Exited with code: $exit_code"
+      echo "Exited with code: ${exit_code}"
       echo "If composer exited part way through without reason, it may have run out of memory"
       echo "Stop all other running containers and try again."
       echo "Composer needs about 1.7GB of memory to install Magento and 0.7GB to install other packages"
@@ -25,23 +21,21 @@ run_composer() {
 
 }
 
-echo "Enter folder name [magento]:"
 MAGENTO_PATH="${MAGENTO_PATH:-magento}"
-mkdir -p "$MAGENTO_PATH"
-cd "$MAGENTO_PATH" || exit 1
+mkdir -p "${MAGENTO_PATH}"
+cd "${MAGENTO_PATH}" || exit 1
 
 if [ ! -f "composer.json" ]; then
-  echo "Start of installing magento..."
-  echo "Enter magento version: "
+  echo "Installing magento..."
   MAGENTO_VERSION="${MAGENTO_VERSION:-2.3.5}"
-  if [ -z "$MAGENTO_VERSION" ]; then
+  if [ -z "${MAGENTO_VERSION}" ]; then
     MAGENTO_COMPOSER="magento/project-community-edition"
   else
     MAGENTO_COMPOSER="magento/project-community-edition=$MAGENTO_VERSION"
   fi
 
-  echo "Downloading magento ($MAGENTO_COMPOSER)..."
-  run_composer create-project --prefer-dist --ignore-platform-reqs --repository-url=https://repo.magento.com/ $MAGENTO_COMPOSER .
+  echo "Downloading magento (${MAGENTO_COMPOSER})..."
+  run_composer create-project --prefer-dist --ignore-platform-reqs --repository-url=https://repo.magento.com/ "${MAGENTO_COMPOSER}" .
 
   echo "Downloading required packages..."
 
@@ -49,47 +43,6 @@ if [ ! -f "composer.json" ]; then
   run_composer require --prefer-dist --ignore-platform-reqs \
     kiwicommerce/module-cron-scheduler=1.0.7 \
     kiwicommerce/module-admin-activity \
-    kiwicommerce/module-login-as-customer
-fi
-
-if [ ! -d "./vendor/solvedata/${plugin_composer_name}/.env" ]; then
-  echo "Downloading solvedata package..."
-
-  # Require solvedata/plugins-magento2 package with the --no-interaction flag so it will use SSH to clone the repo
-  #   rather than prompting for a Github API token.
-  # This requires setting up a readonly deploy SSH key in the solvedata/plugins-magento2 repo.
-
-  run_composer config "repositories.${plugin_vcs_name}" vcs "https://github.com/solvedata/${plugin_vcs_name}.git"
-
-  # if [ ! -d ~/".composer/cache/vcs/git-github.com-solvedata-${plugin_vcs_name}.git/" ]; then
-  #   # Leet hax. Clone the repo outside of the the composer container so we
-  #   #  can use the HTTP endpoint, as Composer(for some reason) refuses to
-  #   git clone --mirror "https://github.com/solvedata/${plugin_vcs_name}.git" ~/".composer/cache/vcs/git-github.com-solvedata-${plugin_vcs_name}.git/"
-  # fi
-
-  run_composer require --no-interaction --ignore-platform-reqs "solvedata/${plugin_composer_name}"
-
-
-  ./vendor/solvedata/plugins-magento2/docker/tools.sh install
-  ./vendor/solvedata/plugins-magento2/docker/tools.sh up
-
-  echo "Magento has been installed, but if you are running Docker on Linux you may need to change the permissions on the project directory to ensure PHP & Nginx can both read the files and create new temporary files."
-else
-  ./vendor/solvedata/plugins-magento2/docker/tools.sh down
-  echo "Magento is installed..."
-  echo "Save docker data to temp..."
-  mkdir "${TMP_DIR}/docker"
-  cp ./vendor/solvedata/plugins-magento2/docker/.env "${TMP_DIR}/docker/.env"
-
-  echo "Update solvedata package..."
-  run_composer update --ignore-platform-reqs "solvedata/${plugin_composer_name}"
-
-  echo "Load saved docker data..."
-  cp -a "${TMP_DIR}/docker/." "./vendor/solvedata/${plugin_composer_name}/docker"
-
-  echo "Remove installer temp files"
-  rm -R "${TMP_DIR}"
-
-  ./vendor/solvedata/plugins-magento2/docker/tools.sh up
-  ./vendor/solvedata/plugins-magento2/docker/tools.sh recompile
+    kiwicommerce/module-login-as-customer \
+    solvedata/plugins-magento2
 fi

--- a/install.sh
+++ b/install.sh
@@ -36,9 +36,19 @@ if [ ! -f "composer.json" ]; then
   echo "Downloading magento (${MAGENTO_COMPOSER})..."
   run_composer create-project --prefer-dist --ignore-platform-reqs --repository-url=https://repo.magento.com/ "${MAGENTO_COMPOSER}" .
 
+  # Hack around dotmailer breaking Swagger page (https://magento.stackexchange.com/a/318010)
+  jq --indent 2 --argjson replace '{
+    "replace": {
+        "dotmailer/dotmailer-magento2-extension": "*",
+        "dotmailer/dotmailer-magento2-extension-package": "*",
+        "dotmailer/dotmailer-magento2-extension-enterprise": "*",
+        "dotmailer/dotmailer-magento2-extension-chat": "*"
+    }
+  }' '. + $replace' composer.json | sponge composer.json
+
   echo "Downloading required packages..."
 
-  # Pin kiwicommerce/module-cron-scheduler to v1.0.7 to support Magento versions >= v2.3.5
+  # - Pin kiwicommerce/module-cron-scheduler to v1.0.7 to support Magento versions >= v2.3.5
   run_composer require --prefer-dist --ignore-platform-reqs \
     kiwicommerce/module-cron-scheduler=1.0.7 \
     kiwicommerce/module-admin-activity \

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+set -euxo pipefail
 TMP_DIR=$(mktemp -d)
 
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,10 +2,12 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "centos/8"
+  config.vm.box = "ubuntu/focal64"
 
   config.vm.disk :disk, size: "20GB", primary: true
-  config.vm.network "forwarded_port", guest: 80, host: 8081
+  config.vm.network "forwarded_port", guest: 8081, host: 8081
+
+  config.vm.synced_folder "..", "/src", owner: "www-data", group: "www-data"
 
   config.vm.provider "virtualbox" do |vb|
     vb.cpus = 2
@@ -14,6 +16,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", path: "provision.sh", env: {
     "MAGENTO_REPO_KEY"    => ENV["MAGENTO_REPO_KEY"],
-    "MAGENTO_REPO_SECRET" => ENV["MAGENTO_REPO_SECRET"]
+    "MAGENTO_REPO_SECRET" => ENV["MAGENTO_REPO_SECRET"],
+    "DEBUG"               => 1
   }
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,5 +1,4 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
+require 'fileutils'
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/focal64"
@@ -7,11 +6,24 @@ Vagrant.configure("2") do |config|
   config.vm.disk :disk, size: "20GB", primary: true
   config.vm.network "forwarded_port", guest: 8081, host: 8081
 
-  config.vm.synced_folder "..", "/src", owner: "www-data", group: "www-data"
-
   config.vm.provider "virtualbox" do |vb|
     vb.cpus = 2
     vb.memory = 4 * 1024
+  end
+
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder "..", "/plugins-magento2",
+    owner: "www-data",
+    group: "www-data"
+  config.vm.synced_folder ".composer", "/home/www-data/.composer",
+    owner: "www-data",
+    group: "www-data"
+
+  config.trigger.before :up do |trigger|
+    composer_dir = File.join(__dir__, ".composer")
+    unless File.directory?(composer_dir)
+      FileUtils.mkdir_p(composer_dir)
+    end
   end
 
   config.vm.provision "shell", path: "provision.sh", env: {

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "centos/8"
+
+  config.vm.disk :disk, size: "20GB", primary: true
+  config.vm.network "forwarded_port", guest: 80, host: 8081
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.cpus = 2
+    vb.memory = 4 * 1024
+  end
+
+  config.vm.provision "shell", path: "provision.sh", env: {
+    "MAGENTO_REPO_KEY"    => ENV["MAGENTO_REPO_KEY"],
+    "MAGENTO_REPO_SECRET" => ENV["MAGENTO_REPO_SECRET"]
+  }
+end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,5 +1,14 @@
 require 'fileutils'
 
+# Source environment variables from a `.env` file if it exists
+env_file = File.join(__dir__, ".env")
+if File.exist?(env_file) and File.file?(env_file)
+  File.readlines(env_file)
+    .filter { |line| line =~ /^[^#].*=.+/ }
+    .map { |line| line.strip.split("=") }
+    .each { |values| ENV[values[0]] = values[1] }
+end
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/focal64"
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/focal64"
 
   config.vm.disk :disk, size: "20GB", primary: true
-  config.vm.network "forwarded_port", guest: 8081, host: 8081
+  config.vm.network "forwarded_port", guest: 8091, host: 8091
 
   config.vm.provider "virtualbox" do |vb|
     vb.cpus = 2

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "${DEBUG:-}" ] && set -x
+IFS=$'\n\t'
+
+docker_compose_version='1.28.0'
+
+root_setup () {  
+  # Install docker
+  curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+  sh /tmp/get-docker.sh
+  rm /tmp/get-docker.sh
+
+  systemctl start docker
+  systemctl enable docker
+  usermod -aG docker vagrant
+
+  # Install docker-compose
+  curl -L "https://github.com/docker/compose/releases/download/${docker_compose_version}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+
+  dnf install --assumeyes git
+}
+
+setup () {
+  # Configure Magento's composer auth
+  mkdir -p ~/.composer/
+  (
+    umask 077
+    cat <<EOF > ~/.composer/auth.json
+{
+    "http-basic": {
+        "repo.magento.com": {
+            "username": "${MAGENTO_REPO_KEY}",
+            "password": "${MAGENTO_REPO_SECRET}"
+        }
+    }
+}
+EOF
+  )
+
+  #git clone https://github.com/solvedata/plugins-magento2 ~/plugins-magento2
+  cd ~/plugins-magento2
+
+  sed -i'' 's/--interactive --tty//g' ./install.sh
+  ./install.sh
+}
+
+main () {
+  if [[ -z "${MAGENTO_REPO_KEY:-}" ]] || [[ -z "${MAGENTO_REPO_SECRET:-}" ]]; then
+    (2>&1 echo 'Require environment variables MAGENTO_REPO_KEY & MAGENTO_REPO_SECRET')
+    exit 1
+  fi
+
+  if [[ "$(id -u)" == 0 ]]; then
+    root_setup
+    exec runuser --user vagrant -- "${0}"
+  fi
+
+  setup
+}
+
+if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
+  main "$@"
+fi

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -26,7 +26,7 @@ root_setup () {
   fi
 
   apt-get update
-  apt-get install --yes git jq
+  apt-get install --yes git jq moreutils
 
   usermod --home /home/www-data www-data
   mkdir -p ~www-data

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -53,19 +53,23 @@ EOF
   )
 
   # Install a local magento development environment
-  sed 's/--interactive --tty//g' /src/install.sh > /tmp/magento-install.sh
-  MAGENTO_PATH="${HOME}/magento" bash /tmp/magento-install.sh
+  MAGENTO_PATH="${HOME}/magento" /src/install.sh
 
   # Symlink in the mounted plugin source into the magento's project source directory
-  sudo rm -rf ~/magento/vendor/solvedata/plugins-magento2
+  rm -rf ~/magento/vendor/solvedata/plugins-magento2
   ln -s /src/ ~/magento/vendor/solvedata/plugins-magento2
 
   # Perform first time setup and configuration for the magento development environment
   (
     cd ~/magento/vendor/solvedata/plugins-magento2/docker
 
-    ./tools.sh magento_install
-    ./tools.sh run_cron
+    if [ ! -f .env ]; then
+      sed "s|^NGINX_HOST_SITE_PATH=.*|NGINX_HOST_SITE_PATH=${HOME}/magento|" .env.example > .env
+    fi
+
+    ./tools.sh up
+    ./tools.sh setup_magento
+    ./tools.sh setup_cron
   )
 }
 


### PR DESCRIPTION
This PR adds a Vagrantfile which runs Magento localdev store in docker-compose.

Setup should ideally be as easy as the following:
```
export MAGENTO_REPO_KEY='...'
export MAGENTO_REPO_SECRET='...'

vagrant up
```

I don't think this Vagrant localdev setup is ideal on the developer experience front, there is a lot of unnecessary complexity and gotchas that can catch you out. As a result of this PR I believe I think we now know enough of how this project is setup to attempt a pure docker-compose based localdev setup that mounts in the source directory. I also would like to simply & consolidate the `install.sh`, `tools.sh` & `provison.sh` scripts. In the meantime this PR should allow people to work on the plugin.