### PR TITLE
Ensure order and cart events have timestamps consistent with Magento

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/CheckoutCartSaveAfter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/CheckoutCartSaveAfter.php
@@ -7,8 +7,8 @@ namespace SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation;
 class CheckoutCartSaveAfter extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation createOrUpdateCart($input: CartInput!) {
-    createOrUpdateCart(input: $input) {
+mutation createOrUpdateCart($input: CartInput!, $options: CreateOrUpdateCartOptions!) {
+    createOrUpdateCart(input: $input, options: $options) {
         profile_id
     }
 }
@@ -31,8 +31,19 @@ GRAPHQL;
             $payload['quoteAllVisibleItems'],
             $payload['area']
         );
-        $input['lastInteractionAt'] = $this->payloadConverter->getFormattedDatetime($event['created_at']);
 
-        return ['input' => $input];
+        // Use the timestamp of when the event was enqueued as the event's "occurred at" time.
+        // Note that this the time when the event was created not when the cart was created.
+        $occurredAt = $this->payloadConverter->getFormattedDatetime($event['created_at']);
+
+        $input['lastInteractionAt'] = $occurredAt;
+        $options = [
+            'occurred_at' => $occurredAt
+        ];
+
+        return [
+            'input' => $input,
+            'options' => $options
+        ];
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
@@ -12,8 +12,8 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\PayloadConverter;
 class ConvertCart extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation convertCart($id: String!, $orderId: String, $provider: String!, options: ConvertCartOptions!) {
-    convertCart(id: $id, orderId: $orderId, provider: $provider) {
+mutation convertCart($id: String!, $orderId: String, $provider: String!, $options: ConvertCartOptions!) {
+    convertCart(id: $id, orderId: $orderId, provider: $provider, options: $options) {
         profile_id
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
@@ -12,7 +12,7 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\PayloadConverter;
 class ConvertCart extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation convertCart($id: String!, $orderId: String, $provider: String!) {
+mutation convertCart($id: String!, $orderId: String, $provider: String!, options: ConvertCartOptions!) {
     convertCart(id: $id, orderId: $orderId, provider: $provider) {
         profile_id
     }
@@ -88,11 +88,19 @@ GRAPHQL;
     public function getVariables(): array
     {
         $payload = $this->getEvent()['payload'];
+        $order = $payload['order'];
+
+        $occurredAt = !empty($order[OrderInterface::CREATED_AT]) ?
+            $this->payloadConverter->getFormattedDatetime($order[OrderInterface::CREATED_AT])
+            : null;
 
         return [
-            'id'       => $payload['order'][OrderInterface::QUOTE_ID],
-            'orderId'  => $payload['order'][OrderInterface::INCREMENT_ID],
+            'id'       => $order[OrderInterface::QUOTE_ID],
+            'orderId'  => $order[OrderInterface::INCREMENT_ID],
             'provider' => $this->payloadConverter->getOrderProvider($payload['area']),
+            'options'  => [
+                'occurred_at' => $occurredAt
+            ]
         ];
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdatePayment.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdatePayment.php
@@ -10,8 +10,8 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbst
 class CreateOrUpdatePayment extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation create_or_update_payment($input: PaymentInput!) {
-    create_or_update_payment(input: $input) {
+mutation create_or_update_payment($input: PaymentInput!, $options: CreateOrUpdatePaymentOptions!) {
+    create_or_update_payment(input: $input, options: $options) {
         id
     }
 }
@@ -48,13 +48,22 @@ GRAPHQL;
      */
     public function getVariables(): array
     {
-        $payload = $this->getEvent()['payload'];
+        $event = $this->getEvent();
+        $payload = $event['payload'];
+
+        // Use the timestamp of when the event was enqueued as the event's "occurred at" time.
+        // Note that this the time when the event was created not when the order was created.
+        $occurredAt = $this->payloadConverter->getFormattedDatetime($event['created_at']);
+        $options = [
+            'occurred_at' => $occurredAt
+        ];
 
         return [
             'input' => $this->payloadConverter->convertPaymentData(
                 $payload['order'],
                 $payload['area']
             ),
+            'options' => $options
         ];
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateReturn.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateReturn.php
@@ -10,8 +10,8 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbst
 class CreateOrUpdateReturn extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation create_or_update_return($input: ReturnInput!) {
-    create_or_update_return(input: $input) {
+mutation create_or_update_return($input: ReturnInput!, $options: CreateOrUpdateReturnOptions!) {
+    create_or_update_return(input: $input, options: $options) {
         id
     }
 }
@@ -48,13 +48,22 @@ GRAPHQL;
      */
     public function getVariables(): array
     {
-        $payload = $this->getEvent()['payload'];
+        $event = $this->getEvent();
+        $payload = $event['payload'];
+
+        // Use the timestamp of when the event was enqueued as the event's "occurred at" time.
+        // Note that this the time when the event was created not when the order was created.
+        $occurredAt = $this->payloadConverter->getFormattedDatetime($event['created_at']);
+        $options = [
+            'occurred_at' => $occurredAt
+        ];
 
         return [
             'input' => $this->payloadConverter->convertReturnData(
                 $payload['order'],
                 $payload['area']
             ),
+            'options' => $options
         ];
     }
 }

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -854,6 +854,10 @@ class PayloadConverter
             'cart_url'   => $this->getReclaimCartUrl($quote, $area)
         ];
 
+        if (!empty($quote['created_at'])) {
+            $data['created_at'] = $this->getFormattedDatetime($quote['created_at']);
+        }
+
         if (!empty($quote['customer_email'])) {
             // Defensively handle a failed profile ID lookup in case
             //  the cart can be retroactively linked to a profile.

--- a/docker/tools.sh
+++ b/docker/tools.sh
@@ -71,6 +71,7 @@ case "${command}" in
         echo "Performing first time setup of Magento"
 
         # shellcheck disable=SC1004
+        # shellcheck disable=SC2016
          docker_compose exec php-fpm sh -c '
             sudo -u www-data php bin/magento setup:install \
                 --base-url="http://${MAGENTO_WEB_ADDRESS}:${MAGENTO_WEB_PORT}/" \

--- a/tests/mutations/ConvertCartTest.php
+++ b/tests/mutations/ConvertCartTest.php
@@ -313,6 +313,10 @@ PAYLOAD;
             ->disableOriginalConstructor()
             ->getMock();
         
+        $quoteIdMaskFactory = $this->getMockBuilder('Magento\Quote\Model\QuoteIdMaskFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
         $logger = $this->getMockBuilder('SolveData\Events\Model\Logger')
             ->disableOriginalConstructor()
             ->getMock();
@@ -322,6 +326,7 @@ PAYLOAD;
             $profileHelper,
             $regionFactory,
             $storeManager,
+            $quoteIdMaskFactory,
             $logger
         );
     }

--- a/tests/mutations/CreateOrUpdateOrderTest.php
+++ b/tests/mutations/CreateOrUpdateOrderTest.php
@@ -18,7 +18,7 @@ PAYLOAD;
         $mutation = new CreateOrUpdateOrder(
             $this->createPayloadConverter()
         );
-        $mutation->setEvent(['payload' => $payload]);
+        $mutation->setEvent(['created_at' => '2021-06-01 01:23:00', 'payload' => $payload]);
 
         $this->assertTrue($mutation->isAllowed());
     }
@@ -49,7 +49,7 @@ PAYLOAD;
         $mutation = new CreateOrUpdateOrder(
             $this->createPayloadConverter()
         );
-        $mutation->setEvent(['payload' => $payload]);
+        $mutation->setEvent(['created_at' => '2021-06-01 01:23:00', 'payload' => $payload]);
 
         $variables = $mutation->getVariables();
 
@@ -103,7 +103,7 @@ PAYLOAD;
         $mutation = new CreateOrUpdateOrder(
             $this->createPayloadConverter()
         );
-        $mutation->setEvent(['payload' => $payload]);
+        $mutation->setEvent(['created_at' => '2021-06-01 01:23:00', 'payload' => $payload]);
 
         $variables = $mutation->getVariables();
 
@@ -129,6 +129,10 @@ PAYLOAD;
             ->disableOriginalConstructor()
             ->getMock();
         
+        $quoteIdMaskFactory = $this->getMockBuilder('Magento\Quote\Model\QuoteIdMaskFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
         $logger = $this->getMockBuilder('SolveData\Events\Model\Logger')
             ->disableOriginalConstructor()
             ->getMock();
@@ -138,6 +142,7 @@ PAYLOAD;
             $profileHelper,
             $regionFactory,
             $storeManager,
+            $quoteIdMaskFactory,
             $logger
         );
     }

--- a/tests/mutations/CreateOrUpdatePaymentTest.php
+++ b/tests/mutations/CreateOrUpdatePaymentTest.php
@@ -138,6 +138,10 @@ PAYLOAD;
             ->disableOriginalConstructor()
             ->getMock();
         
+        $quoteIdMaskFactory = $this->getMockBuilder('Magento\Quote\Model\QuoteIdMaskFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
         $logger = $this->getMockBuilder('SolveData\Events\Model\Logger')
             ->disableOriginalConstructor()
             ->getMock();
@@ -147,6 +151,7 @@ PAYLOAD;
             $profileHelper,
             $regionFactory,
             $storeManager,
+            $quoteIdMaskFactory,
             $logger
         );
     }

--- a/tests/mutations/CreateOrUpdateReturnTest.php
+++ b/tests/mutations/CreateOrUpdateReturnTest.php
@@ -144,6 +144,10 @@ PAYLOAD;
             ->disableOriginalConstructor()
             ->getMock();
         
+        $quoteIdMaskFactory = $this->getMockBuilder('Magento\Quote\Model\QuoteIdMaskFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
         $logger = $this->getMockBuilder('SolveData\Events\Model\Logger')
             ->disableOriginalConstructor()
             ->getMock();
@@ -153,6 +157,7 @@ PAYLOAD;
             $profileHelper,
             $regionFactory,
             $storeManager,
+            $quoteIdMaskFactory,
             $logger
         );
     }

--- a/tests/mutations/RegisterCustomerTest.php
+++ b/tests/mutations/RegisterCustomerTest.php
@@ -18,7 +18,7 @@ PAYLOAD;
         $mutation = new RegisterCustomer(
             $this->createPayloadConverter()
         );
-        $mutation->setEvent(['payload' => $payload]);
+        $mutation->setEvent(['create_at' => '2021-06-01 01:23:00', 'payload' => $payload]);
 
         $this->assertTrue($mutation->isAllowed());
     }
@@ -37,7 +37,7 @@ PAYLOAD;
         $mutation = new RegisterCustomer(
             $this->createPayloadConverter()
         );
-        $mutation->setEvent(['payload' => $payload]);
+        $mutation->setEvent(['create_at' => '2021-06-01 01:23:00', 'payload' => $payload]);
 
         $variables = $mutation->getVariables();
         $this->assertArrayHasKey('email', $variables['input']);
@@ -65,6 +65,10 @@ PAYLOAD;
             ->disableOriginalConstructor()
             ->getMock();
         
+        $quoteIdMaskFactory = $this->getMockBuilder('Magento\Quote\Model\QuoteIdMaskFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
         $logger = $this->getMockBuilder('SolveData\Events\Model\Logger')
             ->disableOriginalConstructor()
             ->getMock();
@@ -74,6 +78,7 @@ PAYLOAD;
             $profileHelper,
             $regionFactory,
             $storeManager,
+            $quoteIdMaskFactory,
             $logger
         );
     }


### PR DESCRIPTION
This PR fixes the inconsistent event timing between frontend SDK events & backend Magento events that customers see in a profile timeline in Solve.

It does this by:
- Setting the `created_at` date to the same instant as the Magento cart's `created_at`
- Setting `occurred_at` to the event's `created_at` time (the time that the event was persisted into the `solvedata_event` queue table) for the following GraphQL mutations
  - `create_or_update_order`
  - `create_or_update_cart`
  - `create_or_update_payment`
  - `create_or_update_return`
- Setting `occurred_at` to the order's `created_at` time for the `convert_cart` mutation

The PR also contains these unrelated fixes:
- Fixes current failing unit tests by adding in the missing dependency (regress caused by #51)
- Ignores another shellcheck warning in `docker/tools.sh`

Screenshot from Solve's profile timeline for a customer who created a cart, converted, paid & returned an item
<img width="815" alt="Screen Shot 2021-06-10 at 2 29 34 PM" src="https://user-images.githubusercontent.com/6936148/121455347-60522280-c9f8-11eb-8be7-94ed4739ffc7.png">
Note that events like `order_created` is ordered correctly in regards to the surrounding pageviews.
