### PR TITLE
Add more context to order state empty warnings

### DIFF
--- a/Controller/Cart/Reclaim.php
+++ b/Controller/Cart/Reclaim.php
@@ -71,7 +71,7 @@ class Reclaim extends \Magento\Framework\App\Action\Action
                 ]);
             }
         } else {
-            $this->logger->warn('Failed to reclaim cart: empty quote id passed to cart reclaim.', [
+            $this->logger->warning('Failed to reclaim cart: empty quote id passed to cart reclaim.', [
                 'masked_quote_id' => $maskedQuoteId,
                 'params' => $params
             ]);
@@ -91,7 +91,7 @@ class Reclaim extends \Magento\Framework\App\Action\Action
             $checkoutSession = $this->cart->getCheckoutSession();
             return $checkoutSession->getQuote()->getId();
         } catch (\Throwable $t) {
-            $this->logger->warn('Failed to get existing cart id before reclaiming a cart.', [
+            $this->logger->warning('Failed to get existing cart id before reclaiming a cart.', [
                 'exception' => $t
             ]);
 

--- a/Model/Event/RegisterHandler/Sales/OrderCancel.php
+++ b/Model/Event/RegisterHandler/Sales/OrderCancel.php
@@ -25,11 +25,15 @@ class OrderCancel extends EventAbstract
         $order = $observer->getEvent()->getOrder();
         try {
             if (empty($order->getState())) {
-                $this->logger->info('order state is empty for order ' . $order->getEntityId());
+                // Throw an exception in order to generate a backtrace on the warning
                 throw new \Exception('Order state is empty');
             }
         } catch (\Exception $e) {
-            $this->logger->warning($e);
+            $this->logger->warning('Order state is empty', [
+                'exception' => $e,
+                'entityId' => $order->getEntityId(),
+                'eventName' => $this->getEventName()
+            ]);
         }
 
         return $this;

--- a/Model/Event/RegisterHandler/Sales/OrderSave.php
+++ b/Model/Event/RegisterHandler/Sales/OrderSave.php
@@ -25,11 +25,15 @@ class OrderSave extends EventAbstract
         $order = $observer->getEvent()->getOrder();
         try {
             if (empty($order->getState())) {
-                $this->logger->info('order state is empty for order ' . $order->getEntityId());
+                // Throw an exception in order to generate a backtrace on the warning
                 throw new \Exception('Order state is empty');
             }
         } catch (\Exception $e) {
-            $this->logger->warning($e);
+            $this->logger->warning('Order state is empty', [
+                'exception' => $e,
+                'entityId' => $order->getEntityId(),
+                'eventName' => $this->getEventName()
+            ]);
         }
 
         return $this;

--- a/Model/Event/RegisterHandler/Sales/OrderShipmentSave.php
+++ b/Model/Event/RegisterHandler/Sales/OrderShipmentSave.php
@@ -21,16 +21,19 @@ class OrderShipmentSave extends EventAbstract
     {
         parent::beforeProcess($observer);
 
-        /** @var Shipment $shipment */
-        $shipment = $observer->getEvent()->getShipment();
-        $order = $shipment->getOrder();
+        /** @var Order $order */
+        $order = $observer->getEvent()->getOrder();
         try {
             if (empty($order->getState())) {
-                $this->logger->info('order state is empty for order ' . $order->getEntityId());
+                // Throw an exception in order to generate a backtrace on the warning
                 throw new \Exception('Order state is empty');
             }
         } catch (\Exception $e) {
-            $this->logger->warning($e);
+            $this->logger->warning('Order state is empty', [
+                'exception' => $e,
+                'entityId' => $order->getEntityId(),
+                'eventName' => $this->getEventName()
+            ]);
         }
 
         return $this;

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -887,7 +887,7 @@ class PayloadConverter
 
             return $this->getLinkUrl($area, 'solve/cart/reclaim', $params);
         } catch (\Throwable $t) {
-            $this->logger->warn('Failed to create reclaim cart url', [
+            $this->logger->warning('Failed to create reclaim cart url', [
                 'exception' => $t,
                 'quote' => $quote
             ]);


### PR DESCRIPTION
- Adds a little more context to the order state empty warnings & takes advantage of the recent Sentry changes so Sentry will parse the backtrace
- Fixes our (... or mine 😁) inconsistent use of `warn` vs `warning`. Appears like MonoLog 1.x allows you to use either overload while 2.x has removed `warn` in favour of `warning`. Therefore I decided it was best to consolidate on `warning`.