### PR TITLE
Set the reached checkout flag on the customer's cart when checkout is started

### DIFF
--- a/Model/Event/RegisterHandler/Controller/StartCheckout.php
+++ b/Model/Event/RegisterHandler/Controller/StartCheckout.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolveData\Events\Model\Event\RegisterHandler\Controller;
+
+use Magento\Checkout\Model\Cart;
+use Magento\Framework\Event\Observer;
+use SolveData\Events\Helper\Customer as CustomerHelper;
+use SolveData\Events\Helper\Event as EventHelper;
+use SolveData\Events\Model\Config;
+use SolveData\Events\Model\Event\RegisterHandler\Converter;
+use SolveData\Events\Model\Event\RegisterHandler\EventAbstract;
+use SolveData\Events\Model\EventRepository;
+use SolveData\Events\Model\Logger;
+
+class StartCheckout extends EventAbstract
+{
+    private $cart;
+
+    public function __construct(
+        Config $config,
+        Converter $converter,
+        CustomerHelper $customerHelper,
+        EventHelper $eventHelper,
+        EventRepository $eventRepository,
+        Logger $logger,
+        Cart $cart
+    ) {
+        $this->cart = $cart;
+
+        parent::__construct($config, $converter, $customerHelper, $eventHelper, $eventRepository, $logger);
+    }
+
+    /**
+     * Get observer data
+     *
+     * @param Observer $observer
+     *
+     * @return EventAbstract
+     *
+     * @throws \Exception
+     */
+    public function prepareData(Observer $observer): EventAbstract
+    {
+        $quote = $this->cart->getQuote();
+        $quoteAllVisibleItems = $quote->getAllVisibleItems();
+
+        // Add final price to payload
+        foreach ($quote->getAllVisibleItems() as $item) {
+            $item->setData('final_price', $item->getProduct()->getFinalPrice());
+        }
+
+        $this->setAffectedEntityId((int)$quote->getEntityId())
+            ->setPayload([
+                'quote'                => $quote,
+                'quoteAllVisibleItems' => $quoteAllVisibleItems,
+                'quoteReachedCheckout' => true,
+                'area'                 => $this->eventHelper->getAreaPayloadData($quote->getStoreId())
+            ]);
+
+        return $this;
+    }
+}

--- a/Model/Event/RegisterHandler/Converter.php
+++ b/Model/Event/RegisterHandler/Converter.php
@@ -46,6 +46,7 @@ class Converter
         foreach ($data as $key => $item) {
             if (is_scalar($item)) {
                 $result[$key] = $item;
+                continue;
             }
             if (is_array($item)) {
                 $result[$key] = (new DataObject($item))->debug();

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/CheckoutCartSaveAfter/CreateOrUpdateCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/CheckoutCartSaveAfter/CreateOrUpdateCart.php
@@ -28,10 +28,16 @@ GRAPHQL;
         $event = $this->getEvent();
         $payload = $event['payload'];
 
+        $options = [];
+        if (!empty($payload['quoteReachedCheckout'])) {
+            $options['reachedCheckout'] = true;
+        }
+
         $input = $this->payloadConverter->convertCartData(
             $payload['quote'],
             $payload['quoteAllVisibleItems'],
-            $payload['area']
+            $payload['area'],
+            $options
         );
 
         // Use the timestamp of when the event was enqueued as the event's "occurred at" time.

--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -906,6 +906,10 @@ class PayloadConverter
             $data['profile_id'] = !empty($profileId) ? $profileId : null;
         }
 
+        if (!empty($options['reachedCheckout'])) {
+            $data['reached_checkout'] = true;
+        }
+
         return $data;
     }
 

--- a/Observer/Controller/StartCheckoutObserver.php
+++ b/Observer/Controller/StartCheckoutObserver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SolveData\Events\Observer\Controller;
+
+use SolveData\Events\Model\Config;
+use SolveData\Events\Model\EventRepository;
+use SolveData\Events\Model\Event\RegisterHandler\Controller\StartCheckout;
+use SolveData\Events\Model\Logger;
+use SolveData\Events\Observer\ObserverAbstract;
+
+class StartCheckoutObserver extends ObserverAbstract
+{
+    /**
+     * @param Config $config
+     * @param EventRepository $eventRepository
+     * @param Logger $logger
+     * @param OrderCancel $handler
+     */
+    public function __construct(
+        Config $config,
+        EventRepository $eventRepository,
+        Logger $logger,
+        StartCheckout $handler
+    ) {
+        parent::__construct($config, $eventRepository, $logger, $handler);
+    }
+}

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -4,7 +4,7 @@
         <solvedata_events>
             <general>
                 <enabled>0</enabled>
-                <enabled_events>sales_order_save_after,sales_order_shipment_save_after,customer_register_success,customer_account_edited,customer_address_save_after,customer_login,customer_logout,checkout_cart_save_after,newsletter_subscriber_save_commit_after,order_cancel_after,sales_quote_merge_after</enabled_events>
+                <enabled_events>sales_order_save_after,sales_order_shipment_save_after,customer_register_success,customer_account_edited,customer_address_save_after,customer_login,customer_logout,checkout_cart_save_after,newsletter_subscriber_save_commit_after,order_cancel_after,sales_quote_merge_after,controller_action_predispatch_checkout_index_index</enabled_events>
                 <enabled_anonymous_cart_events>0</enabled_anonymous_cart_events>
                 <enabled_convert_historical_carts>0</enabled_convert_historical_carts>
                 <hmac_secret backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -44,8 +44,12 @@
         <observer name="order_cancel_after_data"
                   instance="SolveData\Events\Observer\Sales\OrderCancelAfterObserver" />
     </event>
-        <event name="sales_quote_merge_after">
+    <event name="sales_quote_merge_after">
         <observer name="sales_quote_merge_after"
                   instance="SolveData\Events\Observer\Sales\QuoteMergeAfterObserver" />
+    </event>
+    <event name="controller_action_predispatch_checkout_index_index">
+        <observer name="controller_action_predispatch_checkout_index_index"
+                  instance="SolveData\Events\Observer\Controller\StartCheckoutObserver" />
     </event>
 </config>

--- a/etc/solvedata_events.xml
+++ b/etc/solvedata_events.xml
@@ -46,5 +46,12 @@
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesQuoteMergeAfter\CreateOrUpdateDestinationQuote"/>
             <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\SalesQuoteMergeAfter\CreateOrUpdateSourceQuote"/>
         </event>
+
+        <!-- Controller events -->
+
+        <event name="controller_action_predispatch_checkout_index_index">
+            <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\CheckoutCartSaveAfter\CreateOrUpdateCustomer"/>
+            <mutation class="SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\CheckoutCartSaveAfter\CreateOrUpdateCart"/>
+        </event>
     </solvedata_events>
 </config>


### PR DESCRIPTION
This PR adds an observer that listens to `controller_action_predispatch_checkout_index_index` events, and queues up an event to create/update the session's cart with an extra flag called `quoteReachedCheckout` set.

This PR also fixed a long standing bug in the payload converter that prevented any scalars from being serialized in the top level of the payload.