### PR TITLE
Don't attempt mutations if key data isn't present

### DIFF
--- a/Model/Event/RegisterHandler/Controller/StartCheckout.php
+++ b/Model/Event/RegisterHandler/Controller/StartCheckout.php
@@ -33,6 +33,25 @@ class StartCheckout extends EventAbstract
     }
 
     /**
+     * Event is allowed
+     *
+     * @param Observer $observer
+     *
+     * @return bool
+     *
+     * @throws NoSuchEntityException
+     */
+    protected function isAllowed(Observer $observer): bool
+    {
+        if (!parent::isAllowed($observer)) {
+            return false;
+        }
+        
+        $quote = $this->cart->getQuote();
+        return !empty($quote) && !empty($quote->getId());
+    }
+
+    /**
      * Get observer data
      *
      * @param Observer $observer

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesQuoteMergeAfter/CreateOrUpdateDestinationQuote.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesQuoteMergeAfter/CreateOrUpdateDestinationQuote.php
@@ -17,6 +17,18 @@ mutation createOrUpdateCart($input: CartInput!, $options: CreateOrUpdateCartOpti
 GRAPHQL;
 
     /**
+     * Mutation is allowed
+     *
+     * @return bool
+     */
+    public function isAllowed(): bool
+    {
+        $event = $this->getEvent();
+        $payload = $event['payload'];
+        return !empty($payload['quote']['entity_id']);
+    }
+
+    /**
      * Get variables for GraphQL request
      *
      * @return array

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesQuoteMergeAfter/CreateOrUpdateSourceQuote.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesQuoteMergeAfter/CreateOrUpdateSourceQuote.php
@@ -17,6 +17,18 @@ mutation createOrUpdateCart($input: CartInput!, $options: CreateOrUpdateCartOpti
 GRAPHQL;
 
     /**
+     * Mutation is allowed
+     *
+     * @return bool
+     */
+    public function isAllowed(): bool
+    {
+        $event = $this->getEvent();
+        $payload = $event['payload'];
+        return !empty($payload['source']['entity_id']);
+    }
+
+    /**
      * Get variables for GraphQL request
      *
      * @return array

--- a/Observer/ObserverAbstract.php
+++ b/Observer/ObserverAbstract.php
@@ -65,8 +65,11 @@ abstract class ObserverAbstract implements ObserverInterface
 
             $this->handler->process($observer);
         } catch (\Throwable $throwable) {
-            $this->logger->debug('Failed to process event');
-            $this->logger->error($throwable);
+            $this->logger->error('Failed to process event', [
+                'exception' => $throwable,
+                'observer' => self::class,
+                'eventHandler' => get_class($this->handler)
+            ]);
         }
 
         return $this;


### PR DESCRIPTION
This PR adds defensive checks to prevent the extension from attempting mutations which will fail as key data in the event is missing.

While these errors were handled so the impact is minimal, we want to prevent noisy errors in our logs.