### PR TITLE
Fix regression in order shipment save's event handler

### DIFF
--- a/Model/Event/RegisterHandler/Sales/OrderShipmentSave.php
+++ b/Model/Event/RegisterHandler/Sales/OrderShipmentSave.php
@@ -21,8 +21,9 @@ class OrderShipmentSave extends EventAbstract
     {
         parent::beforeProcess($observer);
 
-        /** @var Order $order */
-        $order = $observer->getEvent()->getOrder();
+        /** @var Shipment $shipment */
+        $shipment = $observer->getEvent()->getShipment();
+        $order = $shipment->getOrder();
         try {
             if (empty($order->getState())) {
                 // Throw an exception in order to generate a backtrace on the warning


### PR DESCRIPTION
We need to ensure we retrieve the order via the shipment object in the order shipment events. This regression was introduced by an accidental copy and paste error.