### PR TITLE
Fix occurred at for imported orders

### DIFF
--- a/Model/Event.php
+++ b/Model/Event.php
@@ -235,9 +235,10 @@ class Event extends AbstractModel
                 $orderExtension = $this->orderExtensionFactory->create();
             }
             $orderExtension->setIsImportToSolveData(true);
-
-            // Load addresses if addresses is null
+            
+            // Hydrate the model's address & payment information before serializing.
             $order->getAddresses();
+            $order->getPayment();
 
             try {
                 $data = [

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdatePayment.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdatePayment.php
@@ -50,17 +50,25 @@ GRAPHQL;
     {
         $event = $this->getEvent();
         $payload = $event['payload'];
+        $order = $payload['order'];
 
-        // Use the timestamp of when the event was enqueued as the event's "occurred at" time.
-        // Note that this the time when the event was created not when the order was created.
-        $occurredAt = $this->payloadConverter->getFormattedDatetime($event['created_at']);
+        $isRealtimeEvent = empty($order['extension_attributes']['is_import_to_solve_data']);
+        if ($isRealtimeEvent) {
+            // Use the timestamp of when the event was enqueued as the event's "occurred at" time.
+            // Note that this the time when the event was created not when the order was created.
+            $occurredAt = $event['created_at'];
+        } else {
+            // The order is being imported. Use the order's "created at" field to approximate the "occurred at" time.
+            $occurredAt = $order['created_at'];
+        }
+                
         $options = [
-            'occurred_at' => $occurredAt
+            'occurred_at' => $this->payloadConverter->getFormattedDatetime($occurredAt)
         ];
 
         return [
             'input' => $this->payloadConverter->convertPaymentData(
-                $payload['order'],
+                $order,
                 $payload['area']
             ),
             'options' => $options

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateReturn.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateReturn.php
@@ -50,17 +50,25 @@ GRAPHQL;
     {
         $event = $this->getEvent();
         $payload = $event['payload'];
+        $order = $payload['order'];
 
-        // Use the timestamp of when the event was enqueued as the event's "occurred at" time.
-        // Note that this the time when the event was created not when the order was created.
-        $occurredAt = $this->payloadConverter->getFormattedDatetime($event['created_at']);
+        $isRealtimeEvent = empty($order['extension_attributes']['is_import_to_solve_data']);
+        if ($isRealtimeEvent) {
+            // Use the timestamp of when the event was enqueued as the event's "occurred at" time.
+            // Note that this the time when the event was created not when the order was created.
+            $occurredAt = $event['created_at'];
+        } else {
+            // The order is being imported. Use the order's "created at" field to approximate the "occurred at" time.
+            $occurredAt = $order['created_at'];
+        }
+                
         $options = [
-            'occurred_at' => $occurredAt
+            'occurred_at' => $this->payloadConverter->getFormattedDatetime($occurredAt)
         ];
 
         return [
             'input' => $this->payloadConverter->convertReturnData(
-                $payload['order'],
+                $order,
                 $payload['area']
             ),
             'options' => $options

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Magento 2 Solve Data extension",
   "license": "Apache-2.0",
   "type": "magento2-module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "require": {
     "php": "~7.2",
     "magento/module-catalog": ">=103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SolveData_Events" setup_version="2.0.0">
+    <module name="SolveData_Events" setup_version="2.0.1">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Checkout"/>


### PR DESCRIPTION
This PR uses the order's "created at" timestamp as Solve's special occurred_at timestamps when importing orders into Solve.

It also fixes a bug where the payment details aren't present in imported order's payloads.