### PR TITLE
Pass exceptions into the logger's context record

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -756,7 +756,7 @@ class PayloadConverter
                 ];
             }
         } catch (\Throwable $t) {
-            $this->logger->error('Unexpected error while extracting Store Credit', $t);
+            $this->logger->error('Unexpected error while extracting Store Credit', ['exception' => $t]);
         }
 
         return $adjustments;

--- a/Plugin/Quote/QuoteInterceptor.php
+++ b/Plugin/Quote/QuoteInterceptor.php
@@ -99,7 +99,7 @@ class QuoteInterceptor
             }
             return false;
         } catch (\Throwable $t) {
-            $this->logger->error('shouldUseCustomMerge check failed', $t);
+            $this->logger->error('shouldUseCustomMerge check failed', ['exception' => $t]);
         }
     }
 }


### PR DESCRIPTION
Fixes incorrect logger signature from being used inside error logging code paths that would result in uncaught exceptions from being thrown if these code paths were to be excised in production.