### PR TITLE
Bump extension version to v2.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Magento 2 Solve Data extension",
   "license": "Apache-2.0",
   "type": "magento2-module",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "require": {
     "php": "~7.2",
     "magento/module-catalog": ">=103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SolveData_Events" setup_version="2.0.1">
+    <module name="SolveData_Events" setup_version="2.0.3">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Checkout"/>


### PR DESCRIPTION
The `v2.0.2` release omitted the correct version in `composer.json` & `etc/module.xml`. This PR bumps the version up to `v2.0.3` to rectify this.