### PR TITLE
Pin sentry client to beta version

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -745,15 +745,18 @@ class PayloadConverter
         // Store Credit is an Adobe Commerce only feature (paid Magento)
         // https://docs.magento.com/user-guide/sales/store-credit.html
         try {
-            $storeCredit = $order['customer_balance_invoiced'];
-            // Note PHP does type coersion from string to float, if it is a string
-            // (We are being paranoid here about whether $storeCredit is a
-            // float or a string but it seems to be a float in real data)
-            if (!empty($storeCredit) && is_numeric($storeCredit) && $storeCredit > 0) {
-                $adjustments[] = [
-                    'amount'      => sprintf('-%.4F', $storeCredit),
-                    'description' => 'Store credit',
-                ];
+            if (!empty($order['customer_balance_invoiced'])) {
+                $storeCredit = $order['customer_balance_invoiced'];
+
+                // Note PHP does type coercion from string to float, if it is a string
+                // (We are being paranoid here about whether $storeCredit is a
+                // float or a string but it seems to be a float in real data)
+                if (is_numeric($storeCredit) && $storeCredit > 0) {
+                    $adjustments[] = [
+                        'amount'      => sprintf('-%.4F', $storeCredit),
+                        'description' => 'Store credit',
+                    ];
+                }
             }
         } catch (\Throwable $t) {
             $this->logger->error('Unexpected error while extracting Store Credit', ['exception' => $t]);

--- a/Model/Logger/Handler/Sentry.php
+++ b/Model/Logger/Handler/Sentry.php
@@ -36,19 +36,23 @@ class Sentry extends AbstractHandler
      */
     public function handle(array $record): bool
     {
-        $hub = $this->sentryHubManager->getHub();
-        if (is_null($hub)) {
+        try {
+            $hub = $this->sentryHubManager->getHub();
+            if (is_null($hub)) {
+                return false;
+            }
+    
+            $level = $record['level'];
+            if ($level < Logger::WARNING) {
+                $this->logBreadcrumb($hub, $record);
+            } else {
+                $this->logError($hub, $record);
+            }
+    
+            return false;
+        } catch (\Throwable $t) {
             return false;
         }
-
-        $level = $record['level'];
-        if ($level < Logger::WARNING) {
-            $this->logBreadcrumb($hub, $record);
-        } else {
-            $this->logError($hub, $record);
-        }
-
-        return false;
     }
 
     private function logError(HubInterface $hub, array $record): void

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "magento/module-cron": ">=100.3",
     "magento/module-customer": ">=102.0",
     "magento/module-sales": ">=102.0",
-    "sentry/sentry": "^3.0.0-beta1",
+    "sentry/sentry": "3.0.0-beta1",
     "symfony/http-client": "^5.0",
     "nyholm/psr7": "^1.3.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Magento 2 Solve Data extension",
   "license": "Apache-2.0",
   "type": "magento2-module",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "require": {
     "php": "~7.2",
     "magento/module-catalog": ">=103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SolveData_Events" setup_version="2.0.3">
+    <module name="SolveData_Events" setup_version="2.0.4">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Checkout"/>


### PR DESCRIPTION
This PR fixes a regression introduced by #55 where the extension's use of Sentry was compatible with Sentry clients `>=3.0.0` but not the `3.0.0-beta1` version itself. The inclusion of the `3.0.0-beta1` Sentry version was done to support a particular environment whose transitive dependencies prevented composer from being able to resolve other versions.

The changes introduced in #55 worked with the version of Sentry resolved in our development & testing environments but failed when paired with Sentry version `^3.0.0-beta1`.

This PR fixes the Sentry version to `^3.0.0-beta1` in order to get predictable behaviour with a version known to work in client environments.

A future PR could investigate the feasibility of switching Sentry to use a version from `^2.0` as it's undesirable to be pined to a particular beta version in the long term.