### PR TITLE
Remove unnecessary element in view causing error in Magento 2.3.4

### DIFF
--- a/view/adminhtml/ui_component/solvedata_events_event_listing.xml
+++ b/view/adminhtml/ui_component/solvedata_events_event_listing.xml
@@ -17,11 +17,6 @@
                 </settings>
             </action>
         </massaction>
-        <argument name="data" xsi:type="array">
-            <item name="config" xsi:type="array">
-                <item name="sticky" xsi:type="boolean">false</item>
-            </item>
-        </argument>
         <columnsControls name="columns_controls"/>
         <filterSearch name="fulltext"/>
         <filters name="listing_filters" />


### PR DESCRIPTION
I'm unsure whether Magento 2.3.4 doesn't support the sticky parameter or whether the way its defined is actually invalid.

Either way the sticky parameter simply controls whether or not the top toolbar is visible when you scroll down. We wouldn't mind if it was configured either way.