### PR TITLE
SOLV 3319: Index events created at

### DIFF
--- a/Model/ResourceModel/Event.php
+++ b/Model/ResourceModel/Event.php
@@ -76,10 +76,6 @@ class Event extends AbstractDb
             ])
             ->where('attempt < ?', $this->config->getMaxAttemptCount())
             ->where('scheduled_at < ?', new \Zend_Db_Expr('NOW()'))
-            ->order('status ' . Select::SQL_DESC)
-            ->order('scheduled_at ' . Select::SQL_ASC)
-            ->order('created_at ' . Select::SQL_ASC)
-            // Use the auto-incrementing ID as a tiebreaker since the datetime only use second-level precision
             ->order('id ' . Select::SQL_ASC)
             ->limit($this->config->getCronBatchSize());
 

--- a/Setup/Patch/Schema/AddCreatedAtIndexToSolvedataEvents.php
+++ b/Setup/Patch/Schema/AddCreatedAtIndexToSolvedataEvents.php
@@ -43,7 +43,6 @@ class AddCreatedAtIndexToSolvedataEvents implements SchemaPatchInterface
                 ['created_at'],
                 AdapterInterface::INDEX_TYPE_INDEX
             );
-            // TODO do the other migrations even work?
         }
 
         $connection->endSetup();

--- a/Setup/Patch/Schema/AddCreatedAtIndexToSolvedataEvents.php
+++ b/Setup/Patch/Schema/AddCreatedAtIndexToSolvedataEvents.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SolveData\Events\Setup\Patch\Schema;
+
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\SchemaPatchInterface;
+use SolveData\Events\Model\ResourceModel\Event as ResourceModel;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+
+class AddCreatedAtIndexToSolvedataEvents implements SchemaPatchInterface
+{
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    protected $moduleDataSetup;
+
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply()
+    {
+        $connection = $this->moduleDataSetup->getConnection();
+        $connection->startSetup();
+        $tableName = $connection->getTableName(ResourceModel::TABLE_NAME);
+
+        if (!$this->indexAlreadyExists($connection->getIndexList($tableName))) {
+            $connection->addIndex(
+                $tableName,
+                $connection->getIndexName(
+                    ResourceModel::TABLE_NAME,
+                    ['created_at'],
+                    AdapterInterface::INDEX_TYPE_INDEX
+                ),
+                ['created_at'],
+                AdapterInterface::INDEX_TYPE_INDEX
+            );
+            // TODO do the other migrations even work?
+        }
+
+        $connection->endSetup();
+    }
+
+    private function indexAlreadyExists($indexes): bool {
+        foreach ($indexes as $indexName => $indexData) {
+            if ($indexData['COLUMNS_LIST'] == ['created_at']) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}

--- a/Setup/Patch/Schema/DropSidUniqueIndexInSolvedataProfileTable.php
+++ b/Setup/Patch/Schema/DropSidUniqueIndexInSolvedataProfileTable.php
@@ -54,7 +54,6 @@ class DropSidUniqueIndexInSolvedataProfileTable implements SchemaPatchInterface
         $connection->startSetup();
         $tableName = $connection->getTableName(ResourceModel::TABLE_NAME);
 
-        // TODO tcan this even work
         $connection->addIndex(
             $connection->getIndexName(
                 ResourceModel::TABLE_NAME,
@@ -62,7 +61,7 @@ class DropSidUniqueIndexInSolvedataProfileTable implements SchemaPatchInterface
                 AdapterInterface::INDEX_TYPE_UNIQUE
             ),
             ['sid'],
-            ['type' => AdapterInterface::INDEX_TYPE_UNIQUE]
+            AdapterInterface::INDEX_TYPE_UNIQUE
         );
 
         $connection->endSetup();

--- a/Setup/Patch/Schema/DropSidUniqueIndexInSolvedataProfileTable.php
+++ b/Setup/Patch/Schema/DropSidUniqueIndexInSolvedataProfileTable.php
@@ -54,6 +54,7 @@ class DropSidUniqueIndexInSolvedataProfileTable implements SchemaPatchInterface
         $connection->startSetup();
         $tableName = $connection->getTableName(ResourceModel::TABLE_NAME);
 
+        // TODO tcan this even work
         $connection->addIndex(
             $connection->getIndexName(
                 ResourceModel::TABLE_NAME,


### PR DESCRIPTION
Before index:

```
mysql> explain select * from solvedata_event where created_at > '2020-01-01 00:00:00';
+----+-------------+-----------------+------------+------+---------------+------+---------+------+------+----------+-------------+
| id | select_type | table           | partitions | type | possible_keys | key  | key_len | ref  | rows | filtered | Extra       |
+----+-------------+-----------------+------------+------+---------------+------+---------+------+------+----------+-------------+
|  1 | SIMPLE      | solvedata_event | NULL       | ALL  | NULL          | NULL | NULL    | NULL |    1 |   100.00 | Using where |
+----+-------------+-----------------+------------+------+---------------+------+---------+------+------+----------+-------------+
1 row in set, 1 warning (0.00 sec)
```

After creating index:

```
mysql> explain select * from solvedata_event where created_at > '2020-01-01 00:00:00';
+----+-------------+-----------------+------------+-------+----------------------------+----------------------------+---------+------+------+----------+-----------------------+
| id | select_type | table           | partitions | type  | possible_keys              | key                        | key_len | ref  | rows | filtered | Extra                 |
+----+-------------+-----------------+------------+-------+----------------------------+----------------------------+---------+------+------+----------+-----------------------+
|  1 | SIMPLE      | solvedata_event | NULL       | range | SOLVEDATA_EVENT_CREATED_AT | SOLVEDATA_EVENT_CREATED_AT | 4       | NULL |    1 |   100.00 | Using index condition |
+----+-------------+-----------------+------------+-------+----------------------------+----------------------------+---------+------+------+----------+-----------------------+
1 row in set, 1 warning (0.00 sec)

mysql> show indexes from solvedata_event;
+-----------------+------------+-----------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table           | Non_unique | Key_name                                | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+-----------------+------------+-----------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| solvedata_event |          0 | PRIMARY                                 |            1 | id          | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| solvedata_event |          1 | SOLVEDATA_EVENT_STORE_ID_STORE_STORE_ID |            1 | store_id    | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| solvedata_event |          1 | SOLVEDATA_EVENT_CREATED_AT              |            1 | created_at  | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
+-----------------+------------+-----------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
```

I also didn't put in a revert() function [because](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/declarative-schema/data-patches.html#revertingDataPatches)

> Magento does not allow you to revert a particular module data patch.

Not even `bin/magento module:uninstall --non-composer solvedata/plugins-magento2` triggers the revert anyway.

Also the migration is idempotent to avoid duplicating the index that already exists in Bobux