### PR TITLE
Reduce default event retention to 7 days

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -72,7 +72,7 @@
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
                 <field id="event_retention_period" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Event Retention Period (i.e. 30 days)</label>
+                    <label>Event Retention Period (i.e. 7 days)</label>
                 </field>
             </group>
             <group id="api" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,7 +12,7 @@
                 <cron_batch_size>100</cron_batch_size>
                 <transaction_batch_size>10</transaction_batch_size>
                 <sentry_dsn backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
-                <event_retention_period>30 days</event_retention_period>
+                <event_retention_period>7 days</event_retention_period>
                 <enabled_custom_cart_merge>0</enabled_custom_cart_merge>
             </general>
             <api>


### PR DESCRIPTION
This PR reduces the default event retention period to 7 days inside the `solvedata_event` MySQL queueing table.

A reduction in the retention period means that Magento environments will have lower disk usage due to this extension, while 7 days is more than enough time to respond to incidents without losing data from the queue.