### PR TITLE
Fix incorrect event payload being cached when multiple events of the same type are processed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Magento 2 Solve Data extension",
   "license": "Apache-2.0",
   "type": "magento2-module",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "require": {
     "php": "~7.2",
     "magento/module-catalog": ">=103.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SolveData_Events" setup_version="2.1.0">
+    <module name="SolveData_Events" setup_version="2.1.1">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Checkout"/>


### PR DESCRIPTION
The Magento extension uses a single instance of for each event handling strategy (i.e. subclasses of the `EventAbstract` abstract base class).

This is problematic because these strategies are also mutable and therefore there is the chance for data from one event to sweep into the processing of another completely different event.

While most fields would be overwritten with the new event's data, the payload field had its serialization result cached in a hidden field by the `EventAbstract` abstract base class. This resulted in subsequent events of the same type to reuse the payload from the first event and therefore effectively throwing away these subsequent events.

This bug fix, removes the complicated payload serialization caching in favour of serializing the payload just before it gets inserted into the DB. Additionally this PR calls `$this->unsetData()` at the end of `EventAbstract`'s `process()` function to ensure no other fields can sweep into subsequent events.

This bug has been present since the first version of the extension, however it was only exercised when multiple events of the same type were to be processed within the same PHP process which hasn't been an issue for the standard Magento integration.