### PR TITLE
Rebrand UI text to use the term Solve rather than Solve Data

### DIFF
--- a/Console/Command/Import/Customer.php
+++ b/Console/Command/Import/Customer.php
@@ -45,7 +45,7 @@ class Customer extends ImportAbstract
     protected function configure()
     {
         $this->setName('solve:import:customers');
-        $this->setDescription('Import customers to Solve Data.');
+        $this->setDescription('Import customers to Solve.');
 
         parent::configure();
     }
@@ -77,7 +77,7 @@ class Customer extends ImportAbstract
         try {
             $affectedRows = $this->import($input, $output);
             $output->writeln(sprintf(
-                '<info>You have added to queue %d customer(s) for import to Solve Data.</info>',
+                '<info>You have added to queue %d customer(s) for import to Solve.</info>',
                 $affectedRows
             ));
         } catch (\Throwable $t) {

--- a/Console/Command/Import/Order.php
+++ b/Console/Command/Import/Order.php
@@ -45,7 +45,7 @@ class Order extends ImportAbstract
     protected function configure()
     {
         $this->setName('solve:import:orders');
-        $this->setDescription('Import orders to Solve Data.');
+        $this->setDescription('Import orders to Solve.');
 
         parent::configure();
     }
@@ -77,7 +77,7 @@ class Order extends ImportAbstract
         try {
             $affectedRows = $this->import($input, $output);
             $output->writeln(sprintf(
-                '<info>You have added to queue %d order(s) for import to Solve Data.</info>',
+                '<info>You have added to queue %d order(s) for import to Solve.</info>',
                 $affectedRows
             ));
         } catch (\Throwable $t) {

--- a/Controller/Adminhtml/Customer/MassImport.php
+++ b/Controller/Adminhtml/Customer/MassImport.php
@@ -55,7 +55,7 @@ class MassImport extends AbstractMassAction
     }
 
     /**
-     * Import selected customers to Solve Data
+     * Import selected customers to Solve
      *
      * @param AbstractCollection $collection
      *
@@ -69,15 +69,15 @@ class MassImport extends AbstractMassAction
 
         if ($countNonImportCustomer && $countImportCustomer) {
             $this->messageManager->addErrorMessage(
-                sprintf('%d customer(s) were not added to queue for import to Solve Data.', $countNonImportCustomer)
+                sprintf('%d customer(s) were not added to queue for import to Solve.', $countNonImportCustomer)
             );
         } else if ($countNonImportCustomer) {
-            $this->messageManager->addErrorMessage('No customer(s) were added to queue for import to Solve Data.');
+            $this->messageManager->addErrorMessage('No customer(s) were added to queue for import to Solve.');
         }
 
         if ($countImportCustomer) {
             $this->messageManager->addSuccessMessage(
-                sprintf('You have added to queue %d customer(s) for import to Solve Data.', $countImportCustomer)
+                sprintf('You have added to queue %d customer(s) for import to Solve.', $countImportCustomer)
             );
         }
 

--- a/Controller/Adminhtml/Event/ResendEvent.php
+++ b/Controller/Adminhtml/Event/ResendEvent.php
@@ -71,7 +71,7 @@ class ResendEvent extends Action
         }
 
         $this->messageManager->addSuccessMessage(
-            sprintf('You have added to queue %d event(s) to resend to Solve Data.', $createdEventsCount)
+            sprintf('You have added to queue %d event(s) to resend to Solve.', $createdEventsCount)
         );
 
         return $this->createRedirection();

--- a/Controller/Adminhtml/Order/MassImport.php
+++ b/Controller/Adminhtml/Order/MassImport.php
@@ -39,7 +39,7 @@ class MassImport extends AbstractMassAction implements HttpPostActionInterface
     }
 
     /**
-     * Import selected orders to Solve Data
+     * Import selected orders to Solve
      *
      * @param AbstractCollection $collection
      *
@@ -53,15 +53,15 @@ class MassImport extends AbstractMassAction implements HttpPostActionInterface
 
         if ($countNonImportOrder && $countImportOrder) {
             $this->messageManager->addErrorMessage(
-                sprintf('%d order(s) were not added to queue for import to Solve Data.', $countNonImportOrder)
+                sprintf('%d order(s) were not added to queue for import to Solve.', $countNonImportOrder)
             );
         } else if ($countNonImportOrder) {
-            $this->messageManager->addErrorMessage('No order(s) were added to queue for import to Solve Data.');
+            $this->messageManager->addErrorMessage('No order(s) were added to queue for import to Solve.');
         }
 
         if ($countImportOrder) {
             $this->messageManager->addSuccessMessage(
-                sprintf('You have added to queue %d order(s) for import to Solve Data.', $countImportOrder)
+                sprintf('You have added to queue %d order(s) for import to Solve.', $countImportOrder)
             );
         }
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Solve Data Inc.
+   Copyright 2021 Solve Data Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Model/Event/RegisterHandler/EventAbstract.php
+++ b/Model/Event/RegisterHandler/EventAbstract.php
@@ -154,7 +154,7 @@ abstract class EventAbstract extends DataObject
     }
 
     /**
-     * Prepared observer data and send to solve data events
+     * Prepared observer data and send to solve events
      *
      * @return EventAbstract
      *

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See [Magento's documentation on events and observers](https://devdocs.magento.co
     ```
 1. Run `php bin/magento setup:upgrade`
 1. Run `php bin/magento setup:di:compile`
-1. Go to Solve configs in Admin Panel `Stores > Configuration > Services > Solve Data`
+1. Go to Solve configs in Admin Panel `Stores > Configuration > Services > Solve`
 1. Enable you new event in `Enabled Events`
 1. Click "Save Config"
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "solvedata/plugins-magento2",
-  "description": "Magento 2 Solve Data extension",
+  "description": "Solve Magento 2 extension",
   "license": "Apache-2.0",
   "type": "magento2-module",
   "version": "2.1.1",

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
         <add id="SolveData_Events::event"
-             title="Solve Data"
+             title="Solve"
              translate="title"
              module="SolveData_Events"
              parent="Magento_Backend::system"
@@ -10,7 +10,7 @@
              dependsOnModule="SolveData_Events"
              resource="SolveData_Events::event"/>
         <add id="SolveData_Events::event_listing"
-             title="Events"
+             title="Event Queue"
              translate="title"
              module="SolveData_Events"
              parent="SolveData_Events::event"

--- a/view/adminhtml/ui_component/customer_listing.xml
+++ b/view/adminhtml/ui_component/customer_listing.xml
@@ -6,7 +6,7 @@
                 <settings>
                     <url path="solvedata_events/customer/massImport"/>
                     <type>import_to_solvedata</type>
-                    <label translate="true">Import To Solve Data</label>
+                    <label translate="true">Import To Solve</label>
                 </settings>
             </action>
         </massaction>

--- a/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/view/adminhtml/ui_component/sales_order_grid.xml
@@ -6,7 +6,7 @@
                 <settings>
                     <url path="solvedata_events/order/massImport"/>
                     <type>import_to_solvedata</type>
-                    <label translate="true">Import To Solve Data</label>
+                    <label translate="true">Import To Solve</label>
                 </settings>
             </action>
         </massaction>


### PR DESCRIPTION
Simple PR to update the usages of "Solve Data" to "Solve" to be consistent with our branding.
