### PR TITLE
Add coupon code & rule name into order attributes

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
+++ b/Model/Event/Transport/Adapter/GraphQL/PayloadConverter.php
@@ -310,6 +310,14 @@ class PayloadConverter
             $attributes['imported_at'] = $this->getFormattedDatetime();
         }
 
+        if (!empty($order[OrderInterface::COUPON_CODE])) {
+            $attributes['magento_coupon_code'] = $order[OrderInterface::COUPON_CODE];
+        }
+
+        if (!empty($order['coupon_rule_name'])) {
+            $attributes['magento_coupon_rule_name'] = $order['coupon_rule_name'];
+        }
+
         return $attributes;
     }
 


### PR DESCRIPTION
Add `coupon_code` & `coupon_rule_name` order fields into the Solve order's attribute metadata if those fields exist.

This will allow us to identify orders using specific coupon codes.
