### PR TITLE
Add script to sync vendor dir out of Vagrant

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -1,0 +1,24 @@
+.PHONY: up recompile urls sync-vendor
+.DEFAULT_GOAL: up
+
+up:
+	vagrant up
+
+recompile:
+	vagrant ssh -c 'cd ~www-data/magento/vendor/solvedata/plugins-magento2/docker; exec ./tools.sh recompile'
+
+urls:
+	vagrant ssh -c 'cd ~www-data/magento/vendor/solvedata/plugins-magento2/docker; exec ./tools.sh urls'
+
+sync-vendor:
+	vagrant ssh -c 'cd ~www-data/magento; tar --exclude=vendor/solvedata -czf /tmp/vendor.tar.gz vendor/'
+
+	vagrant ssh-config > /tmp/vagrant-ssh-config
+	scp -r -F /tmp/vagrant-ssh-config default:/home/www-data/magento/vendor.tar.gz /tmp/vendor.tar.gz
+
+	rm -rf ../vendor
+	tar xzf /tmp/vendor.tar.gz --directory ../
+
+	rm /tmp/vagrant-ssh-config
+	rm /tmp/vendor.tar.gz
+	vagrant ssh -c 'rm /tmp/vendor.tar.gz'

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -70,9 +70,9 @@ mount_plugin_source() {
   fi
 
   if ! findmnt -- "${mount_dir}/vendor" >/dev/null 2>&1; then
-    # Obscure a vendor directory by mounting an empty tmpfs filesystem over the top.
+    # Obscure the vendor directory by mounting an empty tmpfs filesystem over the top.
     # This vendor directory may exist to contain depdenecies that your IDE needs during local deveoplement.
-    # If we don't obscure this vendor directory Magento's DI compilation will automatically discover it and error.
+    # If we didn't obscure this vendor directory Magento's DI compilation will discover it and error.
 
     if [[ ! -d "${mount_dir}/vendor" ]]; then
       mkdir -p "${mount_dir}/vendor"


### PR DESCRIPTION
This PR enables us to use IDE with code completion by syncing the vendor directory out of Vagrant.