### PR TITLE
Increase the historical event purge batch size by a factor of 5

### DIFF
--- a/Model/ResourceModel/Event.php
+++ b/Model/ResourceModel/Event.php
@@ -19,7 +19,7 @@ class Event extends AbstractDb
 
     const TABLE_NAME = 'solvedata_event';
 
-    const PURGE_HISTORICAL_EVENTS_BATCH_SIZE = 10000;
+    const PURGE_HISTORICAL_EVENTS_BATCH_SIZE = 5000;
 
     /**
      * @var Config

--- a/Model/ResourceModel/Event.php
+++ b/Model/ResourceModel/Event.php
@@ -19,7 +19,7 @@ class Event extends AbstractDb
 
     const TABLE_NAME = 'solvedata_event';
 
-    const PURGE_HISTORICAL_EVENTS_BATCH_SIZE = 1000;
+    const PURGE_HISTORICAL_EVENTS_BATCH_SIZE = 10000;
 
     /**
      * @var Config


### PR DESCRIPTION
We've seen the the historical event purge cron job take serval hours/days to get through a backlog of events to purge.

This PR bumps the batch size it deletes at once by a factor of 10 to 10,000 every minute. This should be a good compromise between prompting deleting historical events while preventing the cronjob from locking the table (or locking the table for too long).