### PR TITLE
Fix/Graphql arg types to bring in line with core schema

### DIFF
--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/CheckoutCartSaveAfter/CreateOrUpdateCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/CheckoutCartSaveAfter/CreateOrUpdateCart.php
@@ -9,7 +9,7 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbst
 class CreateOrUpdateCart extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation createOrUpdateCart($input: CartInput!, $options: CreateOrUpdateCartOptions!) {
+mutation createOrUpdateCart($input: CartInput!, $options: CreateOrUpdateCartOptions) {
     createOrUpdateCart(input: $input, options: $options) {
         profile_id
     }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/CreateOrUpdateOrder.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/CreateOrUpdateOrder.php
@@ -9,7 +9,7 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbst
 class CreateOrUpdateOrder extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation create_or_update_order($input: CreateOrUpdateOrderInput!, $options: CreateOrUpdateOrderOptions!) {
+mutation create_or_update_order($input: CreateOrUpdateOrderInput!, $options: CreateOrUpdateOrderOptions) {
     create_or_update_order(input: $input, options: $options) {
         profile_id
     }
@@ -44,7 +44,7 @@ GRAPHQL;
             // The order is being imported. Use the order's "created at" field to approximate the "occurred at" time.
             $occurredAt = $order['created_at'];
         }
-                
+
         $options = [
             'occurred_at' => $this->payloadConverter->getFormattedDatetime($occurredAt)
         ];

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/ConvertCart.php
@@ -13,7 +13,7 @@ use SolveData\Events\Model\Logger;
 class ConvertCart extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation convertCart($id: String!, $orderId: String, $provider: String!, $options: ConvertCartOptions!) {
+mutation convertCart($id: String!, $orderId: String, $provider: String!, $options: ConvertCartOptions) {
     convertCart(id: $id, orderId: $orderId, provider: $provider, options: $options) {
         profile_id
     }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdatePayment.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdatePayment.php
@@ -10,7 +10,7 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbst
 class CreateOrUpdatePayment extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation create_or_update_payment($input: PaymentInput!, $options: CreateOrUpdatePaymentOptions!) {
+mutation create_or_update_payment($input: PaymentInput!, $options: CreateOrUpdatePaymentOptions) {
     create_or_update_payment(input: $input, options: $options) {
         id
     }
@@ -61,7 +61,7 @@ GRAPHQL;
             // The order is being imported. Use the order's "created at" field to approximate the "occurred at" time.
             $occurredAt = $order['created_at'];
         }
-                
+
         $options = [
             'occurred_at' => $this->payloadConverter->getFormattedDatetime($occurredAt)
         ];

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateReturn.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesOrderSaveAfter/CreateOrUpdateReturn.php
@@ -10,7 +10,7 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbst
 class CreateOrUpdateReturn extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation create_or_update_return($input: ReturnInput!, $options: CreateOrUpdateReturnOptions!) {
+mutation create_or_update_return($input: ReturnInput!, $options: CreateOrUpdateReturnOptions) {
     create_or_update_return(input: $input, options: $options) {
         id
     }
@@ -61,7 +61,7 @@ GRAPHQL;
             // The order is being imported. Use the order's "created at" field to approximate the "occurred at" time.
             $occurredAt = $order['created_at'];
         }
-                
+
         $options = [
             'occurred_at' => $this->payloadConverter->getFormattedDatetime($occurredAt)
         ];

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesQuoteMergeAfter/CreateOrUpdateDestinationQuote.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesQuoteMergeAfter/CreateOrUpdateDestinationQuote.php
@@ -9,7 +9,7 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbst
 class CreateOrUpdateDestinationQuote extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation createOrUpdateCart($input: CartInput!, $options: CreateOrUpdateCartOptions!) {
+mutation createOrUpdateCart($input: CartInput!, $options: CreateOrUpdateCartOptions) {
     createOrUpdateCart(input: $input, options: $options) {
         profile_id
     }

--- a/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesQuoteMergeAfter/CreateOrUpdateSourceQuote.php
+++ b/Model/Event/Transport/Adapter/GraphQL/Mutation/SalesQuoteMergeAfter/CreateOrUpdateSourceQuote.php
@@ -9,7 +9,7 @@ use SolveData\Events\Model\Event\Transport\Adapter\GraphQL\Mutation\MutationAbst
 class CreateOrUpdateSourceQuote extends MutationAbstract
 {
     const QUERY = <<<'GRAPHQL'
-mutation createOrUpdateCart($input: CartInput!, $options: CreateOrUpdateCartOptions!) {
+mutation createOrUpdateCart($input: CartInput!, $options: CreateOrUpdateCartOptions) {
     createOrUpdateCart(input: $input, options: $options) {
         profile_id
     }


### PR DESCRIPTION
Brings graphql variable types in line with our schema.

However, absinthe 1.7 allows for non-null types on nullable inputs, so this change is purely a tidy-up and not required for the rollout of absinthe 1.7. Dodged a bullet here.